### PR TITLE
Use of DispatchGroup

### DIFF
--- a/UserListSampleApp/Remote+JSONDecoder.swift
+++ b/UserListSampleApp/Remote+JSONDecoder.swift
@@ -30,7 +30,6 @@ extension JSONDecoder {
                 self.dateDecodingStrategy = .iso8601
                 let response = try self.decode(type, from: data)
                 DispatchQueue.main.async { // return the data on the main thread
-                    sleep(3)
                     completion(response)
                 }
             } catch {

--- a/UserListSampleApp/UserDataSource.swift
+++ b/UserListSampleApp/UserDataSource.swift
@@ -12,35 +12,45 @@ class UserDataSource: NSObject, UITableViewDataSource {
 
     var users = [User]()
     var dataChanged:(()-> Void)?
+    let dispatchGroup = DispatchGroup()
+
+    func firstCall(_ decoder: JSONDecoder, with urlString: String) {
+        dispatchGroup.enter()
+        decoder.decode([User].self, fromURL: urlString) { users in
+            print("Call 1")
+            self.users.append(contentsOf: users)
+            self.dispatchGroup.leave()
+        }
+    }
+
+    func secondCall(_ decoder: JSONDecoder, with urlString: String) {
+        dispatchGroup.enter()
+        decoder.decode([User].self, fromURL: urlString) { users in
+            print("Call 2")
+            self.users.append(contentsOf: users)
+            self.dispatchGroup.leave()
+        }
+    }
+
+    func thirdCall(_ decoder: JSONDecoder, with urlString: String) {
+        dispatchGroup.enter()
+        decoder.decode([User].self, fromURL: urlString) { users in
+            print("Call 3")
+            self.users.append(contentsOf: users)
+            self.dispatchGroup.leave()
+        }
+    }
+
 
     func fetch(_ urlString: String) {
 
         let decoder = JSONDecoder()
-
-        // Creating async calls
-
-        decoder.decode([User].self, fromURL: urlString) { users in
-            print("Result 1")
-            self.users = users
+        firstCall(decoder, with: urlString)
+        secondCall(decoder, with: urlString)
+        thirdCall(decoder, with: urlString)
+        dispatchGroup.notify(queue: .main) {
             self.dataChanged?()
         }
-        decoder.decode([User].self, fromURL: urlString) { users in
-            print("Result 2")
-            self.users.append(contentsOf: users)
-            self.dataChanged?()
-        }
-        decoder.decode([User].self, fromURL: urlString) { users in
-            print("Result 3")
-            self.users.append(contentsOf: users)
-            self.dataChanged?()
-        }
-
-        decoder.decode([User].self, fromURL: urlString) { users in
-            print("Result 4")
-            self.users.append(contentsOf: users)
-            self.dataChanged?()
-        }
-
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/UserListSampleApp/ViewController.swift
+++ b/UserListSampleApp/ViewController.swift
@@ -13,15 +13,11 @@ class ViewController: UITableViewController {
     var users:[User] = []
     let dataSource = UserDataSource()
 
-
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view, typically from a nib.
-        self.loadData()
-    }
-
-    func loadData() {
         dataSource.dataChanged = { [weak self] in
+            print("Calling reload data")
             self?.tableView.reloadData()
         }
 


### PR DESCRIPTION
This PR highlights the concept of dispatch group.

### Look into the UserDataSource.swift file, there are three network call and the result of every network call returns a list of users which you append back to your main user array. 

If we don't use **DispatchGroup** in all three completion blocks we need to refresh the data by returning the completion block. That would give us result in this fashion,

- First API call. Append the array. Update the table view 
- Second API call. Append the array. Update the table view 
- Third API call. Append the array. Update the table view 

### Assume if the requirement is: Once you receive the data from all the calls then update the UI

In this case, we can use DispatchGroup to achieve the result. Run the code and you could see in this case we can call the completion block on the notification given by the dispatch group once all the tasks are performed, something like this
```

        dispatchGroup.notify(queue: .main) {
            self.dataChanged?()
        }

```

& while making the API call the code can be like,
  
```
    func firstCall(_ decoder: JSONDecoder, with urlString: String) {
        dispatchGroup.enter()
        decoder.decode([User].self, fromURL: urlString) { users in
            print("Call 1")
            self.users.append(contentsOf: users)
            self.dispatchGroup.leave()
        }
    }
```

Notice, we make sure to call  **dispatchGroup.enter()** and then once you receive the call at that time **dispatchgroup.leave()**
 